### PR TITLE
feat: add a Pub/Sub method

### DIFF
--- a/models/mq.go
+++ b/models/mq.go
@@ -1,0 +1,14 @@
+package models
+
+type MQOption struct {
+	Attributes map[string]string
+}
+
+type GetMQOption func(*MQOption) error
+
+func WithAttributes(attributes map[string]string) GetMQOption {
+	return func(opt *MQOption) error {
+		opt.Attributes = attributes
+		return nil
+	}
+}

--- a/mq.go
+++ b/mq.go
@@ -3,6 +3,7 @@ package mq
 import (
 	"context"
 
+	"github.com/A-pen-app/mq/models"
 	"github.com/A-pen-app/mq/pubsub"
 	"github.com/A-pen-app/mq/pubsubLite"
 	"github.com/A-pen-app/mq/rabbitmq"
@@ -10,8 +11,8 @@ import (
 
 type MQ interface {
 	// send some data to a topic
-	Send(topic string, data interface{}, attributes map[string]string) error
-	SendWithContext(ctx context.Context, topic string, data interface{}, attributes map[string]string) error
+	Send(topic string, data interface{}, options ...models.GetMQOption) error
+	SendWithContext(ctx context.Context, topic string, data interface{}, options ...models.GetMQOption) error
 
 	// or, pass messages back to client
 	Receive(topic string) (<-chan []byte, error)

--- a/mq.go
+++ b/mq.go
@@ -3,14 +3,15 @@ package mq
 import (
 	"context"
 
+	"github.com/A-pen-app/mq/pubsub"
 	"github.com/A-pen-app/mq/pubsubLite"
 	"github.com/A-pen-app/mq/rabbitmq"
 )
 
 type MQ interface {
 	// send some data to a topic
-	Send(topic string, data interface{}) error
-	SendWithContext(ctx context.Context, topic string, data interface{}) error
+	Send(topic string, data interface{}, attributes map[string]string) error
+	SendWithContext(ctx context.Context, topic string, data interface{}, attributes map[string]string) error
 
 	// or, pass messages back to client
 	Receive(topic string) (<-chan []byte, error)
@@ -18,8 +19,9 @@ type MQ interface {
 }
 
 type Config struct {
-	Pubsub   *pubsubLite.Config
-	Rabbitmq *rabbitmq.Config
+	Pubsub    *pubsubLite.Config
+	Rabbitmq  *rabbitmq.Config
+	NewPubsub *pubsub.Config
 }
 
 // Initialize ...
@@ -29,10 +31,15 @@ func Initialize(ctx context.Context, config *Config) {
 	}
 	rabbitmq.Initialize(ctx, config.Rabbitmq)
 	pubsubLite.Initialize(ctx, config.Pubsub)
+	pubsub.Initialize(ctx, config.NewPubsub)
 }
 
 func GetPubsub() MQ {
 	return &pubsubLite.Store{}
+}
+
+func GetNewPubsub() MQ {
+	return &pubsub.Store{}
 }
 
 func GetRabbitmq() MQ {
@@ -43,4 +50,5 @@ func GetRabbitmq() MQ {
 func Finalize() {
 	rabbitmq.Finalize()
 	pubsubLite.Finalize()
+	pubsub.Finalize()
 }

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -247,4 +247,5 @@ func Finalize() {
 	for _, v := range publisher {
 		v.Stop()
 	}
+	client.Close()
 }

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -1,15 +1,13 @@
-package pubsubLite
+package pubsub
 
 import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
 	"cloud.google.com/go/pubsub"
-	"cloud.google.com/go/pubsublite/pscompat"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
@@ -19,35 +17,39 @@ import (
 
 var (
 	receiveTimeout = 24 * 60 * 60 * time.Second
-	publisher      = make(map[string]*pscompat.PublisherClient)
+	publisher      = make(map[string]*pubsub.Topic)
+	client         *pubsub.Client
 	c              *Config
 )
 
+type TopicConfig struct {
+	SubscriptionID string
+	Filter         string
+}
+
 type Config struct {
-	ProjectID    string
-	RegionOrZone string
-	Topics       map[string]string
+	ProjectID string
+	Topics    map[string]TopicConfig
 }
 
 type Store struct{}
 
-// FIXME: Reservation, topic, and subscription health check and initialization is to be added in the future.
 func Initialize(ctx context.Context, config *Config) {
 	if config == nil {
 		return
 	}
 
-	for topic := range config.Topics {
-		topicPath := fmt.Sprintf("projects/%s/locations/%s/topics/%s", config.ProjectID, config.RegionOrZone, topic)
+	newClient, err := pubsub.NewClient(ctx, config.ProjectID)
+	if err != nil {
+		return
+	}
 
-		// Create the publisher client.
-		p, err := pscompat.NewPublisherClient(ctx, topicPath)
-		if err != nil {
-			continue
-		}
-		publisher[topic] = p
+	for topic := range config.Topics {
+		t := newClient.Topic(topic)
+		publisher[topic] = t
 	}
 	c = config
+	client = newClient
 }
 
 func (ps *Store) SendWithContext(ctx context.Context, topic string, data interface{}, attributes map[string]string) error {
@@ -70,9 +72,10 @@ func (ps *Store) SendWithContext(ctx context.Context, topic string, data interfa
 	if err != nil {
 		return err
 	}
+
 	msg := pubsub.Message{
 		Data:       payload,
-		Attributes: make(map[string]string),
+		Attributes: attributes,
 	}
 	otel.GetTextMapPropagator().Inject(ctx, propagation.MapCarrier(msg.Attributes))
 
@@ -82,7 +85,6 @@ func (ps *Store) SendWithContext(ctx context.Context, topic string, data interfa
 	}
 	span.SetAttributes(semconv.MessagingMessageIDKey.String(msgID))
 	return nil
-
 }
 
 func (ps *Store) Send(topic string, data interface{}, attributes map[string]string) error {
@@ -106,14 +108,15 @@ func (ps *Store) Send(topic string, data interface{}, attributes map[string]stri
 	}
 
 	msg := &pubsub.Message{
-		Data: payload,
+		Data:       payload,
+		Attributes: attributes,
 	}
 	result := p.Publish(ctx, msg)
 
 	// FIXME: Resend mechanism to be added
 	g.Go(func() error {
 		// Get blocks until the result is ready.
-		id, err := result.Get(ctx)
+		_, err := result.Get(ctx)
 		if err != nil {
 			// NOTE: A failed PublishResult indicates that the publisher client
 			// encountered a fatal error and has permanently terminated. After the
@@ -125,21 +128,9 @@ func (ps *Store) Send(topic string, data interface{}, attributes map[string]stri
 			return err
 		}
 
-		// Metadata decoded from the id contains the partition and offset.
-		_, err = pscompat.ParseMessageMetadata(id)
-		if err != nil {
-			fmt.Printf("Failed to parse message metadata %q: %v\n", id, err)
-			return err
-		}
 		return nil
 	})
 	if err := g.Wait(); err != nil {
-		return err
-	}
-
-	// Print the error that caused the publisher client to terminate (if any),
-	// which may contain more context than PublishResults.
-	if err := p.Error(); err != nil {
 		return err
 	}
 
@@ -147,36 +138,39 @@ func (ps *Store) Send(topic string, data interface{}, attributes map[string]stri
 }
 
 func (ps *Store) ReceiveWithContext(ctx context.Context, topic string) (<-chan []byte, error) {
-	subID, exist := c.Topics[topic]
-	if !exist || len(subID) == 0 {
+	tc, exist := c.Topics[topic]
+	if !exist || len(tc.SubscriptionID) == 0 {
 		return nil, errors.New("topic or subscription not found")
 	}
-	subscriptionPath := fmt.Sprintf("projects/%s/locations/%s/subscriptions/%s", c.ProjectID, c.RegionOrZone, subID)
-	settings := pscompat.ReceiveSettings{
+	settings := pubsub.ReceiveSettings{
 		MaxOutstandingBytes:    10 * 1024 * 1024,
 		MaxOutstandingMessages: 1000,
 	}
-	s, err := pscompat.NewSubscriberClientWithSettings(
-		ctx,
-		subscriptionPath,
-		settings,
-	)
+	subConfig := pubsub.SubscriptionConfig{
+		Topic:  publisher[topic],
+		Filter: tc.Filter,
+	}
+
+	sub, err := client.CreateSubscription(ctx, tc.SubscriptionID, subConfig)
 	if err != nil {
 		return nil, err
 	}
+	sub.ReceiveSettings = settings
+
 	byteCh := make(chan []byte)
 	errCh := make(chan error)
-	go func(ctx context.Context, s *pscompat.SubscriberClient, ch chan []byte, errCh chan error) {
+	go func(ctx context.Context, s *pubsub.Subscription, ch chan []byte, errCh chan error) {
 		if err := s.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 			if msg.Attributes != nil {
 				propagator := otel.GetTextMapPropagator()
 				ctx = propagator.Extract(ctx, propagation.MapCarrier(msg.Attributes))
 			}
+
 			options := []trace.SpanStartOption{
 				trace.WithSpanKind(trace.SpanKindConsumer),
 				trace.WithAttributes(
 					semconv.MessagingSystemKey.String("pubsub"),
-					semconv.MessagingDestinationKey.String(subID),
+					semconv.MessagingDestinationKey.String(tc.SubscriptionID),
 					semconv.MessagingDestinationKindTopic,
 					semconv.MessagingMessageIDKey.String(msg.ID),
 				),
@@ -186,30 +180,27 @@ func (ps *Store) ReceiveWithContext(ctx context.Context, topic string) (<-chan [
 
 			byteCh <- msg.Data
 			msg.Ack()
+
 		}); err != nil {
 			errCh <- err
 		}
-	}(ctx, s, byteCh, errCh)
+	}(ctx, sub, byteCh, errCh)
 
 	return byteCh, nil
-
 }
 
 func (ps *Store) Receive(topic string) (<-chan []byte, error) {
 	ctx := context.Background()
 
-	subID, exist := c.Topics[topic]
-	if !exist || len(subID) == 0 {
+	tc, exist := c.Topics[topic]
+	if !exist || len(tc.SubscriptionID) == 0 {
 		return nil, errors.New("topic or subscription not found")
 	}
 
-	subscriptionPath := fmt.Sprintf("projects/%s/locations/%s/subscriptions/%s", c.ProjectID, c.RegionOrZone, subID)
-
-	// Configure flow control settings. These settings apply per partition.
 	// The message stream is paused based on the maximum size or number of
 	// messages that the subscriber has already received, whichever condition is
 	// met first.
-	settings := pscompat.ReceiveSettings{
+	settings := pubsub.ReceiveSettings{
 		// 10 MiB. Must be greater than the allowed size of the largest message
 		// (1 MiB).
 		MaxOutstandingBytes: 10 * 1024 * 1024,
@@ -217,30 +208,26 @@ func (ps *Store) Receive(topic string) (<-chan []byte, error) {
 		MaxOutstandingMessages: 1000,
 	}
 
-	// Create the subscriber client.
-	s, err := pscompat.NewSubscriberClientWithSettings(
-		ctx,
-		subscriptionPath,
-		settings,
-	)
+	subConfig := pubsub.SubscriptionConfig{
+		Topic:  publisher[topic],
+		Filter: tc.Filter,
+	}
+
+	// Create the subscription.
+	sub, err := client.CreateSubscription(ctx, tc.SubscriptionID, subConfig)
 	if err != nil {
 		return nil, err
 	}
+	sub.ReceiveSettings = settings
 
 	byteCh := make(chan []byte)
 	errCh := make(chan error)
-	go func(ctx context.Context, s *pscompat.SubscriberClient, ch chan []byte, errCh chan error) {
+	go func(ctx context.Context, s *pubsub.Subscription, ch chan []byte, errCh chan error) {
 		for {
 			ctx, cancel := context.WithTimeout(ctx, receiveTimeout)
 
 			// Receive blocks until the context is cancelled or an error occurs.
 			if err = s.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
-				// Metadata decoded from the message ID contains the partition and offset.
-				_, err = pscompat.ParseMessageMetadata(msg.ID)
-				if err != nil {
-					errCh <- err
-					return
-				}
 				byteCh <- msg.Data
 				msg.Ack()
 			}); err != nil {
@@ -249,9 +236,8 @@ func (ps *Store) Receive(topic string) (<-chan []byte, error) {
 
 			cancel()
 		}
-	}(ctx, s, byteCh, errCh)
+	}(ctx, sub, byteCh, errCh)
 
-	// logging.Info(ctx, fmt.Sprintf("Received %d messages\n", receiveCount))
 	return byteCh, nil
 }
 

--- a/pubsubLite/pubsubLite.go
+++ b/pubsubLite/pubsubLite.go
@@ -10,6 +10,7 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"cloud.google.com/go/pubsublite/pscompat"
+	"github.com/A-pen-app/mq/models"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
@@ -50,7 +51,7 @@ func Initialize(ctx context.Context, config *Config) {
 	c = config
 }
 
-func (ps *Store) SendWithContext(ctx context.Context, topic string, data interface{}, attributes map[string]string) error {
+func (ps *Store) SendWithContext(ctx context.Context, topic string, data interface{}, opts ...models.GetMQOption) error {
 	p := publisher[topic]
 	if p == nil {
 		return errors.New("publisher not found")
@@ -85,7 +86,7 @@ func (ps *Store) SendWithContext(ctx context.Context, topic string, data interfa
 
 }
 
-func (ps *Store) Send(topic string, data interface{}, attributes map[string]string) error {
+func (ps *Store) Send(topic string, data interface{}, opts ...models.GetMQOption) error {
 	p := publisher[topic]
 	if p == nil {
 		return errors.New("publisher not found")

--- a/rabbitmq/mq.go
+++ b/rabbitmq/mq.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/A-pen-app/mq/models"
 	amqp "github.com/rabbitmq/amqp091-go"
 )
 
@@ -64,12 +65,12 @@ func clearExchanges() error {
 	return nil
 }
 
-func (p *Store) SendWithContext(ctx context.Context, topic string, data interface{}, attributes map[string]string) error {
+func (p *Store) SendWithContext(ctx context.Context, topic string, data interface{}, opts ...models.GetMQOption) error {
 	// FIXME propagate context through rabbitmq messages
-	return p.Send(topic, data, attributes)
+	return p.Send(topic, data, opts...)
 }
 
-func (p *Store) Send(exchange string, message interface{}, attributes map[string]string) error {
+func (p *Store) Send(exchange string, message interface{}, opts ...models.GetMQOption) error {
 	switch exchange {
 	case TopicNotif:
 		tries := 0

--- a/rabbitmq/mq.go
+++ b/rabbitmq/mq.go
@@ -64,12 +64,12 @@ func clearExchanges() error {
 	return nil
 }
 
-func (p *Store) SendWithContext(ctx context.Context, topic string, data interface{}) error {
+func (p *Store) SendWithContext(ctx context.Context, topic string, data interface{}, attributes map[string]string) error {
 	// FIXME propagate context through rabbitmq messages
-	return p.Send(topic, data)
+	return p.Send(topic, data, attributes)
 }
 
-func (p *Store) Send(exchange string, message interface{}) error {
+func (p *Store) Send(exchange string, message interface{}, attributes map[string]string) error {
 	switch exchange {
 	case TopicNotif:
 		tries := 0


### PR DESCRIPTION
- add `attributes `to the Send and SendWithContext interfaces

The difference between Pub/Sub and Pub/Sub Lite
- add `Attributes `to mes in send and sendWithContext.
- bind SubscriptionID in Receive and ReceiveWithContext

create SubscriptionID and setting filter in gcp
