### PR TITLE
feat: add manual Ack/Nack support via ReceiveWithAck

### DIFF
--- a/models/mq.go
+++ b/models/mq.go
@@ -34,3 +34,21 @@ func WithAttributes(attributes *Attributes) GetMQOption {
 		return nil
 	}
 }
+
+type Message struct {
+	Data     []byte
+	AckFunc  func()
+	NackFunc func()
+}
+
+func (m *Message) Ack() {
+	if m.AckFunc != nil {
+		m.AckFunc()
+	}
+}
+
+func (m *Message) Nack() {
+	if m.NackFunc != nil {
+		m.NackFunc()
+	}
+}

--- a/mq.go
+++ b/mq.go
@@ -14,9 +14,12 @@ type MQ interface {
 	Send(topic string, data interface{}, options ...models.GetMQOption) error
 	SendWithContext(ctx context.Context, topic string, data interface{}, options ...models.GetMQOption) error
 
-	// or, pass messages back to client
+	// or, pass messages back to client (auto-ack)
 	Receive(topic string) (<-chan []byte, error)
 	ReceiveWithContext(ctx context.Context, topic string) (<-chan []byte, error)
+
+	// receive messages with manual Ack/Nack control
+	ReceiveWithAck(ctx context.Context, topic string) (<-chan *models.Message, <-chan error, error)
 }
 
 type Config struct {

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -221,7 +221,7 @@ func (ps *Store) ReceiveWithContext(ctx context.Context, topic string) (<-chan [
 	return byteCh, nil
 }
 
-// ReceiveWithContextAndAck receives messages with manual Ack/Nack control
+// ReceiveWithAck receives messages with manual Ack/Nack control
 func (ps *Store) ReceiveWithAck(ctx context.Context, topic string) (<-chan *models.Message, <-chan error, error) {
 	tc, exist := c.Topics[topic]
 	if !exist || len(tc.SubscriptionID) == 0 {

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -262,7 +262,7 @@ func (ps *Store) ReceiveWithAck(ctx context.Context, topic string) (<-chan *mode
 					semconv.MessagingMessageIDKey.String(msg.ID),
 				),
 			}
-			_, span := otel.Tracer("subscriber:"+topic).Start(ctx, "pubsub.receivewithcontextandack", options...)
+			_, span := otel.Tracer("subscriber:"+topic).Start(ctx, "pubsub.receivewithack", options...)
 			defer span.End()
 
 			wrappedMsg := &models.Message{

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -221,6 +221,65 @@ func (ps *Store) ReceiveWithContext(ctx context.Context, topic string) (<-chan [
 	return byteCh, nil
 }
 
+// ReceiveWithContextAndAck receives messages with manual Ack/Nack control
+func (ps *Store) ReceiveWithAck(ctx context.Context, topic string) (<-chan *models.Message, <-chan error, error) {
+	tc, exist := c.Topics[topic]
+	if !exist || len(tc.SubscriptionID) == 0 {
+		return nil, nil, errors.New("topic or subscription not found")
+	}
+	settings := pubsub.ReceiveSettings{
+		MaxOutstandingBytes:    10 * 1024 * 1024,
+		MaxOutstandingMessages: 1000,
+	}
+
+	// bind the subscription.
+	sub := client.Subscription(tc.SubscriptionID)
+	exists, err := sub.Exists(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("check subscriptionID %s existence failed: %w", tc.SubscriptionID, err)
+	} else if !exists {
+		return nil, nil, fmt.Errorf("subscriptionID %s not found", tc.SubscriptionID)
+	}
+	sub.ReceiveSettings = settings
+
+	msgCh := make(chan *models.Message)
+	errCh := make(chan error)
+	go func(ctx context.Context, s *pubsub.Subscription, ch chan *models.Message, errCh chan error) {
+		defer close(ch)
+		defer close(errCh)
+		if err := s.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+			if msg.Attributes != nil {
+				propagator := otel.GetTextMapPropagator()
+				ctx = propagator.Extract(ctx, propagation.MapCarrier(msg.Attributes))
+			}
+
+			options := []trace.SpanStartOption{
+				trace.WithSpanKind(trace.SpanKindConsumer),
+				trace.WithAttributes(
+					semconv.MessagingSystemKey.String("pubsub"),
+					semconv.MessagingDestinationKey.String(tc.SubscriptionID),
+					semconv.MessagingDestinationKindTopic,
+					semconv.MessagingMessageIDKey.String(msg.ID),
+				),
+			}
+			_, span := otel.Tracer("subscriber:"+topic).Start(ctx, "pubsub.receivewithcontextandack", options...)
+			defer span.End()
+
+			wrappedMsg := &models.Message{
+				Data:     msg.Data,
+				AckFunc:  func() { msg.Ack() },
+				NackFunc: func() { msg.Nack() },
+			}
+			ch <- wrappedMsg
+
+		}); err != nil {
+			errCh <- err
+		}
+	}(ctx, sub, msgCh, errCh)
+
+	return msgCh, errCh, nil
+}
+
 func (ps *Store) Receive(topic string) (<-chan []byte, error) {
 	ctx := context.Background()
 

--- a/pubsubLite/pubsubLite.go
+++ b/pubsubLite/pubsubLite.go
@@ -256,9 +256,10 @@ func (ps *Store) Receive(topic string) (<-chan []byte, error) {
 	return byteCh, nil
 }
 
-// ReceiveWithContextAndAck is not supported for Pub/Sub Lite
+// ReceiveWithAck is not supported for Pub/Sub Lite
 func (ps *Store) ReceiveWithAck(ctx context.Context, topic string) (<-chan *models.Message, <-chan error, error) {
-	return nil, nil, errors.New("ReceiveWithContextAndAck is not supported for Pub/Sub Lite, use ReceiveWithContext instead")
+	return nil, nil, errors.New("ReceiveWithAck is not supported for Pub/Sub Lite, use ReceiveWithContext instead")
+}
 }
 
 // Finalize ...

--- a/pubsubLite/pubsubLite.go
+++ b/pubsubLite/pubsubLite.go
@@ -256,6 +256,11 @@ func (ps *Store) Receive(topic string) (<-chan []byte, error) {
 	return byteCh, nil
 }
 
+// ReceiveWithContextAndAck is not supported for Pub/Sub Lite
+func (ps *Store) ReceiveWithAck(ctx context.Context, topic string) (<-chan *models.Message, <-chan error, error) {
+	return nil, nil, errors.New("ReceiveWithContextAndAck is not supported for Pub/Sub Lite, use ReceiveWithContext instead")
+}
+
 // Finalize ...
 func Finalize() {
 	// Ensure the publisher will be shut down.

--- a/rabbitmq/mq.go
+++ b/rabbitmq/mq.go
@@ -262,6 +262,11 @@ func (p *Store) Receive(topic string) (<-chan []byte, error) {
 	return byteCh, nil
 }
 
+// ReceiveWithContextAndAck is not supported for RabbitMQ
+func (p *Store) ReceiveWithAck(ctx context.Context, topic string) (<-chan *models.Message, <-chan error, error) {
+	return nil, nil, errors.New("ReceiveWithContextAndAck is not supported for RabbitMQ, use ReceiveWithContext instead")
+}
+
 // Finalize ...
 func Finalize() {
 	if client != nil {

--- a/rabbitmq/mq.go
+++ b/rabbitmq/mq.go
@@ -262,9 +262,10 @@ func (p *Store) Receive(topic string) (<-chan []byte, error) {
 	return byteCh, nil
 }
 
-// ReceiveWithContextAndAck is not supported for RabbitMQ
+// ReceiveWithAck is not supported for RabbitMQ
 func (p *Store) ReceiveWithAck(ctx context.Context, topic string) (<-chan *models.Message, <-chan error, error) {
-	return nil, nil, errors.New("ReceiveWithContextAndAck is not supported for RabbitMQ, use ReceiveWithContext instead")
+	return nil, nil, errors.New("ReceiveWithAck is not supported for RabbitMQ, use ReceiveWithContext instead")
+}
 }
 
 // Finalize ...


### PR DESCRIPTION
- Add ReceiveWithAck(ctx, topic) method to MQ interface
- Implement pubsub.Message type with Ack/Nack methods
- Implement ReceiveWithAck for pubsub.Store with error channel
- Add stub implementations for pubsubLite and rabbitmq (not supported)
- Preserve existing Receive/ReceiveWithContext methods (backward compatible)